### PR TITLE
gh-15 : change shabang for compatibility and test for bash 4.3+ and bash as shell

### DIFF
--- a/_tests.sh
+++ b/_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 clear 
 
@@ -9,8 +9,8 @@ set -euo pipefail
 }
 PATH=$(pwd):$PATH
 
-which git 
-git --version
+source "$(dirname "$0")/git-artifact"
+check_environment
 
 cd .test
 root_folder=$(pwd)
@@ -21,7 +21,6 @@ local_tester_repo=.local
 remote_tester_repo=.remote
 clone_tester_repo=.clone
 global_exit_code=0
-
 
 function testcase_header() {
     [[ ${verbose:-} == true ]] || return 0

--- a/git-artifact
+++ b/git-artifact
@@ -1,30 +1,70 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # git-artifact: use a git repository as artifact management storage
 #
 
-if test -z "$GIT_EXEC_PATH" || ! test -f "$GIT_EXEC_PATH/git-sh-setup" || {
-    test "${PATH#"${GIT_EXEC_PATH}:"}" = "$PATH" &&
-    test ! "$GIT_EXEC_PATH" -ef "${PATH%%:*}" 2>/dev/null
-}
-then
-    basename=${0##*[/\\]}
-    echo >&2 'It looks like either your git installation or your'
-    echo >&2 'git-subtree installation is broken.'
-    echo >&2
-    echo >&2 "Tips:"
-    echo >&2 " - If \`git --exec-path\` does not print the correct path to"
-    echo >&2 "   your git install directory, then set the GIT_EXEC_PATH"
-    echo >&2 "   environment variable to the correct directory."
-    echo >&2 " - Make sure that your \`$basename\` file is either in your"
-    echo >&2 "   PATH or in your git exec path (\`$(git --exec-path)\`)."
-    echo >&2 " - You should run git-subtree as \`git ${basename#git-}\`,"
-    echo >&2 "   not as \`$basename\`." >&2
-    exit 126
-fi
+function check_environment() {
+    if [[ "${BASH_VERSINFO:-}" == "" ]] ; then
+        echo "ERROR: git-artifact only runs in bash - please check that the variable BASH_VERSINFO is set"
+        echo "BASH_VERSINFO: ${BASH_VERSINFO:-unknown}"
+        echo "BASH_VERSION: ${BASH_VERSION:-unknown}"
+        echo "SHELL: ${SHELL:-unknown}"
+        exit 1
+    fi
 
+    if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+        echo "ERROR: git-artifact requires Bash version 4.3 or higher."
+        echo "BASH_VERSINFO: ${BASH_VERSINFO:-unknown}"
+        echo "BASH_VERSION: ${BASH_VERSION:-unknown}"
+        exit 1
+    elif [[ "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -lt 3 ]]; then
+        echo "ERROR: git-artifact requires Bash version 4.3 or higher."
+        echo "BASH_VERSINFO: ${BASH_VERSINFO:-unknown}"
+        echo "BASH_VERSION: ${BASH_VERSION:-unknown}"
+        exit 1
+    fi
+
+}
+
+function check_git_environment() {
+        if test -z "$GIT_EXEC_PATH" || ! test -f "$GIT_EXEC_PATH/git-sh-setup" || {
+        test "${PATH#"${GIT_EXEC_PATH}:"}" = "$PATH" &&
+        test ! "$GIT_EXEC_PATH" -ef "${PATH%%:*}" 2>/dev/null
+    }
+    then
+        basename=${0##*[/\\]}
+        echo >&2 'It looks like your git installation broken'
+        echo >&2
+        echo >&2 "Tips:"
+        echo >&2 " - If \`git --exec-path\` does not print the correct path to"
+        echo >&2 "   your git install directory, then set the GIT_EXEC_PATH"
+        echo >&2 "   environment variable to the correct directory."
+        echo >&2 " - Make sure that your \`$basename\` file is either in your"
+        echo >&2 "   PATH or in your git exec path (\`$(git --exec-path)\`)."
+        echo >&2 " - You should run git-subtree as \`git ${basename#git-}\`,"
+        echo >&2 "   not as \`$basename\`." >&2
+        exit 126
+    fi
+
+}
+
+function show_info() {
+    echo "git-artifact: use a git repository as artifact management storage"
+    echo "Version: $(git --version | cut -d ' ' -f 3)"
+    echo "Bash version: ${BASH_VERSION:-unknown}"
+    echo "Bash version info: ${BASH_VERSINFO[*]:-unknown}"
+    echo "Git exec path: ${GIT_EXEC_PATH:-unknown}"
+    echo "Git version: $(git --version)"
+}
+
+function set_opts_spec() {
+    # Set the options specification for git rev-parse --parseopt
+    # This is used to parse command line arguments
+    # It is used in the main function to set the arguments
+    # It is also used in the cmd_* functions to parse the arguments
+    # It is also used in the git artifact help command to show the options
 #inspiration: https://github.com/git/git/blob/master/contrib/subtree/git-subtree.sh
-OPTS_SPEC="\
+    OPTS_SPEC="\
     git artifact commmand <options>
 
 commands:
@@ -61,6 +101,7 @@ r,regex=       the reg-ex pattern to latest of
  options for 'fetch-tags'
 s,sha1=       The sha1 of which to get tags from from 
 "
+}
 
 debug () {
     if test -n "$arg_debug"
@@ -395,6 +436,7 @@ main () {
     done
     arg_command=$1
     shift
+
     which git-sh-setup
     case "$arg_command" in
         init)	if test -z "${arg_remoteurl:-}"  ; then
@@ -485,5 +527,11 @@ main () {
     "cmd_$arg_command" "$@"
 }
 
-
-main "$@"
+# Only run main if not being sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    check_environment
+    check_git_environment
+    [[ ${arg_debug:-} == true ]] && show_info
+    set_opts_spec
+    main "$@"
+fi


### PR DESCRIPTION
- Fixes gh-9 : drawing in readme.md for 2.0/test is not logical placed correctly
- gh-15 : change shabang for compatibility and test for bash 4.3+


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved environment validation and error messaging for scripts, including more comprehensive checks for Bash version and git availability.
  * Enhanced script portability by updating shebang lines.
  * Minor formatting and structural improvements for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->