### PR TITLE
Allow find latest default

### DIFF
--- a/git-artifact
+++ b/git-artifact
@@ -332,11 +332,11 @@ cmd_fetch-co() {
 find-latest() {
     local -n _latest_tag=${1}
     # https://stackoverflow.com/questions/10649814/get-last-git-tag-from-a-remote-repo-without-cloning
-    _latest_tag=$(git ls-remote --tags --refs --sort='-version:refname' origin "${arg_regex:-*}" | head -n 1 | cut  -f2 | cut -d / -f3-) || {
+    _latest_tag=$(git ls-remote --tags --refs --sort='-version:refname' origin "refs/tags/${arg_regex}" | head -n 1 | cut  -f2 | cut -d / -f3-) || {
         local exit_code=$?
         if [[ $exit_code -ne 141 ]]; then 
             #https://unix.stackexchange.com/questions/580117/debugging-sporadic-141-shell-script-errors
-            echo "ERROR: Something unknown happend.."
+            echo "ERROR: Something unknown happened.."
             exit 1
         fi
     } 
@@ -497,10 +497,10 @@ main () {
                 # shellcheck source=/dev/null
                 . git-sh-setup
                 require_work_tree
-                # if test -z "${arg_regex:-}"  ; then
-                #     echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
-                #     arg_regex="*"
-                # fi
+                if test -z "${arg_regex:-}" ; then
+                    # echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
+                    arg_regex="*"
+                fi
                 ;;
         fetch-tags)
                 # shellcheck source=/dev/null

--- a/git-artifact
+++ b/git-artifact
@@ -332,7 +332,7 @@ cmd_fetch-co() {
 find-latest() {
     local -n _latest_tag=${1}
     # https://stackoverflow.com/questions/10649814/get-last-git-tag-from-a-remote-repo-without-cloning
-    _latest_tag=$(git ls-remote --tags --refs --sort='-version:refname' origin ${arg_regex} | head -n 1 | cut  -f2 | cut -d / -f3-) || {
+    _latest_tag=$(git ls-remote --tags --refs --sort='-version:refname' origin "${arg_regex:-*}" | head -n 1 | cut  -f2 | cut -d / -f3-) || {
         local exit_code=$?
         if [[ $exit_code -ne 141 ]]; then 
             #https://unix.stackexchange.com/questions/580117/debugging-sporadic-141-shell-script-errors

--- a/git-artifact
+++ b/git-artifact
@@ -498,7 +498,7 @@ main () {
                 . git-sh-setup
                 require_work_tree
                 if test -z "${arg_regex:-}" ; then
-                    # echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
+                    echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
                     arg_regex="*"
                 fi
                 ;;

--- a/git-artifact
+++ b/git-artifact
@@ -498,9 +498,8 @@ main () {
                 . git-sh-setup
                 require_work_tree
                 if test -z "${arg_regex:-}"  ; then
-                    git artifact -h
-                    echo "ERROR: -r|--regex is required for $arg_command"
-                    exit 1
+                    echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
+                    arg_regex="*"
                 fi
                 ;;
         fetch-tags)

--- a/git-artifact
+++ b/git-artifact
@@ -497,10 +497,10 @@ main () {
                 # shellcheck source=/dev/null
                 . git-sh-setup
                 require_work_tree
-                if test -z "${arg_regex:-}"  ; then
-                    echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
-                    arg_regex="*"
-                fi
+                # if test -z "${arg_regex:-}"  ; then
+                #     echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
+                #     arg_regex="*"
+                # fi
                 ;;
         fetch-tags)
                 # shellcheck source=/dev/null


### PR DESCRIPTION
Update find-latest & fetch-co-latest to work without -r

Right now they require a value to be set in -r/--regex

This PR, updates the method to default the arg_regex to "*" and removes the error on the subcommand if a regex isn't provided

Before:

Running `git artifact find-latest` will print out the help as (-r|--regex) is required

Now:
```
> git artifact find-latest
v1.0

And

> git artifact fetch-co-latest
remote: Enumerating objects: 8, done.
remote: Counting objects: 100% (8/8), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 8 (delta 1), reused 8 (delta 1), pack-reused 0 (from 0)
Unpacking objects: 100% (8/8), 779 bytes | 389.00 KiB/s, done.
From github.com:a-magdy/test-git-artifact
 * [new tag]         v1.0       -> v1.0
HEAD is now at 6ec7f18 v1.0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **New Features**
  * Commands that previously required a regex argument can now run without it, automatically considering all tags by default.

* **Bug Fixes**
  * Corrected a typo in an error message for clearer communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->