### PR TITLE
gh-25 : fixed * as -r parammeter to find-latest

### DIFF
--- a/git-artifact
+++ b/git-artifact
@@ -332,7 +332,7 @@ cmd_fetch-co() {
 find-latest() {
     local -n _latest_tag=${1}
     # https://stackoverflow.com/questions/10649814/get-last-git-tag-from-a-remote-repo-without-cloning
-    _latest_tag=$(git ls-remote --tags --refs --sort='-version:refname' origin ${arg_regex} | head -n 1 | cut  -f2 | cut -d / -f3-) || {
+    _latest_tag=$(git ls-remote --tags --refs --sort='-version:refname' origin "refs/tags/${arg_regex}" | head -n 1 | cut  -f2 | cut -d / -f3-) || {
         local exit_code=$?
         if [[ $exit_code -ne 141 ]]; then 
             #https://unix.stackexchange.com/questions/580117/debugging-sporadic-141-shell-script-errors


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag matching to ensure only tags under the correct namespace are considered when searching for the latest tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->