### PR TITLE
Remove help from the set_opts_spec

### DIFF
--- a/git-artifact
+++ b/git-artifact
@@ -81,7 +81,7 @@ fetch-co-latest Get latest tag form remote using grep reg-ex and reset hard to i
 fetch-tags      Fetch all tags that points to a sha1 or HEAD - Useful in relation to detached HEAD and submodules
 
 --
-h,help          show the help
+h               show the help
 q               quiet
 d               show debug messages
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the help option flag to use only `-h` instead of `-h,help` in the options menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->