### PR TITLE
Allow find latest default

### DIFF
--- a/git-artifact
+++ b/git-artifact
@@ -332,11 +332,11 @@ cmd_fetch-co() {
 find-latest() {
     local -n _latest_tag=${1}
     # https://stackoverflow.com/questions/10649814/get-last-git-tag-from-a-remote-repo-without-cloning
-    _latest_tag=$(git ls-remote --tags --refs --sort='-version:refname' origin "${arg_regex:-*}" | head -n 1 | cut  -f2 | cut -d / -f3-) || {
+    _latest_tag=$(git ls-remote --tags --refs --sort='-version:refname' origin "refs/tags/${arg_regex}" | head -n 1 | cut  -f2 | cut -d / -f3-) || {
         local exit_code=$?
         if [[ $exit_code -ne 141 ]]; then 
             #https://unix.stackexchange.com/questions/580117/debugging-sporadic-141-shell-script-errors
-            echo "ERROR: Something unknown happend.."
+            echo "ERROR: Something unknown happened.."
             exit 1
         fi
     } 
@@ -497,10 +497,10 @@ main () {
                 # shellcheck source=/dev/null
                 . git-sh-setup
                 require_work_tree
-                # if test -z "${arg_regex:-}"  ; then
-                #     echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
-                #     arg_regex="*"
-                # fi
+                if test -z "${arg_regex:-}" ; then
+                    # echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
+                    arg_regex="*"
+                fi
                 ;;
         fetch-tags)
                 # shellcheck source=/dev/null

--- a/git-artifact
+++ b/git-artifact
@@ -332,7 +332,7 @@ cmd_fetch-co() {
 find-latest() {
     local -n _latest_tag=${1}
     # https://stackoverflow.com/questions/10649814/get-last-git-tag-from-a-remote-repo-without-cloning
-    _latest_tag=$(git ls-remote --tags --refs --sort='-version:refname' origin ${arg_regex} | head -n 1 | cut  -f2 | cut -d / -f3-) || {
+    _latest_tag=$(git ls-remote --tags --refs --sort='-version:refname' origin "${arg_regex:-*}" | head -n 1 | cut  -f2 | cut -d / -f3-) || {
         local exit_code=$?
         if [[ $exit_code -ne 141 ]]; then 
             #https://unix.stackexchange.com/questions/580117/debugging-sporadic-141-shell-script-errors

--- a/git-artifact
+++ b/git-artifact
@@ -498,7 +498,7 @@ main () {
                 . git-sh-setup
                 require_work_tree
                 if test -z "${arg_regex:-}" ; then
-                    # echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
+                    echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
                     arg_regex="*"
                 fi
                 ;;

--- a/git-artifact
+++ b/git-artifact
@@ -498,9 +498,8 @@ main () {
                 . git-sh-setup
                 require_work_tree
                 if test -z "${arg_regex:-}"  ; then
-                    git artifact -h
-                    echo "ERROR: -r|--regex is required for $arg_command"
-                    exit 1
+                    echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
+                    arg_regex="*"
                 fi
                 ;;
         fetch-tags)

--- a/git-artifact
+++ b/git-artifact
@@ -497,10 +497,10 @@ main () {
                 # shellcheck source=/dev/null
                 . git-sh-setup
                 require_work_tree
-                if test -z "${arg_regex:-}"  ; then
-                    echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
-                    arg_regex="*"
-                fi
+                # if test -z "${arg_regex:-}"  ; then
+                #     echo "INFO: -r|--regex is not set: Defaulting to '*' (all tags)."
+                #     arg_regex="*"
+                # fi
                 ;;
         fetch-tags)
                 # shellcheck source=/dev/null


### PR DESCRIPTION
Remove a requirement on both `find-latest` & `fetch-co-latest` to have the regex be passed as an input
Instead default it to '*' if not provided

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in error messages for improved clarity.

* **New Features**
  * The regex argument for tag filtering is now optional; if not provided, all tags are considered by default, and users are notified when this default is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->