### PR TITLE
gh-48 : fix add-as-submodule with deeper paths

### DIFF
--- a/.test/10/git-reference.log
+++ b/.test/10/git-reference.log
@@ -7,6 +7,9 @@
 [submodule "submodule-repo"]
 	path = submodule-repo
 	url = ../.remote
+[submodule "subm/deeper/submodule-repo"]
+	path = subm/deeper/submodule-repo
+	url = ../.remote
 On branch main
 Your branch is up to date with 'origin/main'.
 

--- a/_tests.sh
+++ b/_tests.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2317
-# shellcheck disable=SC2329
 
 
 function usage() {
@@ -106,6 +105,7 @@ function testcase_header() {
 }
 
 function generate_git_test_log() {
+    [[ -d .git ]] || { echo "ERROR: Not in a git repository"; return 1; }
     rm -rf .git/refs/remotes/origin/HEAD
     git log --graph --all --oneline --format="%d %s" >> "${root_folder}/${test}/git-test.log"
 }
@@ -324,8 +324,10 @@ function 7 {
         touch test${test}_1.txt
         git artifact add-n-push -t v${test}.1
 
+        cd ${root_folder}/${test}/$local_tester_repo
         generate_git_test_log
-        git artifact list --glob 'v*.*' >> ${root_folder}/${test}/git-test.log
+        cd ${root_folder}
+        git -C ${root_folder}/${test}/$local_tester_repo artifact list --glob 'v*.*' >> ${root_folder}/${test}/git-test.log
     
 
     } > ${root_folder}/${test}/run.log 2>&1 || { pwd && cat ${root_folder}/${test}/run.log; }
@@ -359,6 +361,7 @@ function 8 {
             sleep 1
         done
 
+        cd ${root_folder}/${test}/$local_tester_repo
         generate_git_test_log
         git artifact summary >> ${root_folder}/${test}/git-test.log
 
@@ -412,7 +415,12 @@ function 10 {
         
         cd $local_tester_repo
         
-        git artifact add-as-submodule --url "../$remote_tester_repo" --path submodule-repo
+        git artifact add-as-submodule --url "../$remote_tester_repo" --path submodule-repo || {
+            issue1="ERROR: Adding the submodule repository failed: submodule-repo"
+        }
+        git artifact add-as-submodule --url "../$remote_tester_repo" --path subm/deeper/submodule-repo || {
+            issue2="ERROR: Adding the submodule repository failed: subm/deeper/submodule-repo"
+        }
         
         git status 
 
@@ -421,6 +429,8 @@ function 10 {
         git fetch origin -apP
 
         generate_git_test_log
+        [[ -n "${issue1:-}" ]] && echo "${issue1}" >> ${root_folder}/${test}/git-test.log
+        [[ -n "${issue2:-}" ]] && echo "${issue2}" >> ${root_folder}/${test}/git-test.log
         cat .gitmodules >> ${root_folder}/${test}/git-test.log
         git status >> ${root_folder}/${test}/git-test.log
         
@@ -428,6 +438,7 @@ function 10 {
     eval_testcase
 }
 
+trap 'echo "Script interrupted"; exit 130' INT TERM ERR EXIT HUP QUIT ABRT ALRM PIPE
 
 if [[ ${arg_testcase:-} == "" ]]; then 
     # Dynamically list and call test functions
@@ -438,11 +449,15 @@ if [[ ${arg_testcase:-} == "" ]]; then
             echo "Test case '$fn' failed. Check the logs in .test/$fn/run.log"
             global_exit_code=1
         }
+        echo "ok"
     done
 else
     # Run a specific test case if provided
     if declare -F "$arg_testcase" > /dev/null; then
-        "$arg_testcase"
+        "$arg_testcase" || {
+            echo "Test case '$fn' failed. Check the logs in .test/$fn/run.log"
+            global_exit_code=1
+        }
     else
         echo "Test case '$arg_testcase' not found."
         exit 1

--- a/_tests.sh
+++ b/_tests.sh
@@ -438,8 +438,6 @@ function 10 {
     eval_testcase
 }
 
-trap 'echo "Script interrupted"; exit 130' INT TERM ERR EXIT HUP QUIT ABRT ALRM PIPE
-
 if [[ ${arg_testcase:-} == "" ]]; then 
     # Dynamically list and call test functions
     mapfile -t test_functions < <(declare -F | awk '{print $3}' | grep -E '^[0-9]+(\.[0-9]+)?$')
@@ -449,7 +447,6 @@ if [[ ${arg_testcase:-} == "" ]]; then
             echo "Test case '$fn' failed. Check the logs in .test/$fn/run.log"
             global_exit_code=1
         }
-        echo "ok"
     done
 else
     # Run a specific test case if provided

--- a/_tests.sh
+++ b/_tests.sh
@@ -452,7 +452,7 @@ else
     # Run a specific test case if provided
     if declare -F "$arg_testcase" > /dev/null; then
         "$arg_testcase" || {
-            echo "Test case '$fn' failed. Check the logs in .test/$fn/run.log"
+            echo "Test case '$arg_testcase' failed. Check the logs in .test/$arg_testcase/run.log"
             global_exit_code=1
         }
     else

--- a/git-artifact
+++ b/git-artifact
@@ -407,10 +407,13 @@ cmd_add-as-submodule() {
     fi
 
     # Ensure parent dir for the submodule gitdir exists (supports nested paths)
-    mkdir -p ".git/modules/"
     local modules_gitdir=".git/modules/${arg_path}"
+    mkdir -p "$(dirname "${modules_gitdir}")"
     echo "Cloning repo into ${modules_gitdir} with working tree: ${arg_path}"
-    git clone --single-branch --no-tags --separate-git-dir="${modules_gitdir}" "${arg_remoteurl}" "${arg_path}"
+    git clone --single-branch --no-tags --separate-git-dir="${modules_gitdir}" "${arg_remoteurl}" "${arg_path}" || {
+        echo "ERROR: Cloning the submodule repository failed"
+        return 1
+    }
 
     echo "Adding the repo as submodule"
     git submodule add --force "${arg_remoteurl}" "${arg_path}"


### PR DESCRIPTION
with error message:
```
fatal: Invalid path '/home/claus/git-artifact/.test/10/.local/.git/modules/subm': No such file or directory
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer failure handling for submodule operations with explicit error messages and safer directory creation.
  * Improved runtime validation to ensure operations run inside a repository.

* **Tests**
  * Stronger test execution: per-test isolation via directory handling, better aggregation of submodule issues, and appended per-test logs.
  * Improved failure messaging that points to test logs and returns proper exit codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->